### PR TITLE
Bank improvements

### DIFF
--- a/Assets/Scripts/Bank.cs
+++ b/Assets/Scripts/Bank.cs
@@ -1,6 +1,43 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 public class Bank : MonoBehaviour
 {
-	public int money;
+	[SerializeField]
+	private int money;
+
+	public int Money
+	{
+		get => money;
+
+		private set
+		{
+			money = value;
+			OnMoneyChanged?.Invoke(money);
+		}
+	}
+
+	public Action<int> OnMoneyChanged = delegate { };
+
+	public bool CanDepositMoney(int amount) => !(amount < 0);
+	public bool CanWithdrawMoney(int amount) => !(amount < 0 || amount > money);
+
+	public bool DepositMoney(int amount)
+	{
+		if (!CanDepositMoney(amount))
+			return false;
+
+		Money += amount;
+		return true;
+	}
+
+	public bool WithdrawMoney(int amount)
+	{
+		if (!CanWithdrawMoney(amount))
+			return false;
+
+		Money -= amount;
+		return true;
+	}
+
 }

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -66,7 +66,7 @@ public class Enemy : MonoBehaviour, IDamageable
         health -= damage;
         if(health <= 0)
         {
-            bank.money += money;
+            bank.DepositMoney(money);
             Die();
         }
     }


### PR DESCRIPTION
- Money in the Bank must now be modified via the DepositMoney and WithdrawMoney methods.
- Bank prevents invalid transactions (transactions that cause the balance to go negative)
- Helper methods CanDepositMoney and CanWithdrawMoney can be used to check if a transaction is valid ahead of time
- The optional OnMoneyChanged event can be a cheaper alternative to polling the Money variable. UI elements (and any C# object) can subscribe to the OnMoneyChanged event to be notified when the Money in the Bank has changed;